### PR TITLE
ci: Add Open Source Policy Workflow

### DIFF
--- a/.github/workflows/repolinter.yml
+++ b/.github/workflows/repolinter.yml
@@ -1,0 +1,29 @@
+name: Repolinter Action
+
+# NOTE: This workflow will ONLY check the default branch!
+# Currently there is no elegant way to specify the default
+# branch in the event filtering, so branches are instead
+# filtered in the "Test Default Branch" step.
+on: [push]
+
+jobs:
+  repolint:
+    name: Run Repolinter
+    runs-on: ubuntu-latest
+    steps:
+      - name: Test Default Branch
+        id: default-branch
+        uses: actions/github-script@v2
+        with:
+          script: |
+            const data = await github.repos.get(context.repo)
+            return data.data && data.data.default_branch === context.ref.split('/').slice(-1)[0]
+      - name: Checkout Self
+        if: ${{ steps.default-branch.outputs.result == 'true' }}
+        uses: actions/checkout@v2
+      - name: Run Repolinter
+        if: ${{ steps.default-branch.outputs.result == 'true' }}
+        uses: newrelic/repolinter-action@v1
+        with:
+          config_url: TODO
+          output_type: issue


### PR DESCRIPTION
Hello from the Open Source and Developer Advocacy team at New Relic! This PR contains a GitHub actions workflow which runs repolinter, an automated tool to help us find and fix inconsistencies in our community files and public repositories. This PR registers a GitHub Actions workflow (`repolinter.yml`) running [repolinter-action](https://github.com/newrelic/repolinter-action). The goal of this workflow is to make our Open Source Policy enforcement more consistent and transparent for everyone.

Repolinter Action does:
 * Scans the repository for Open Source policy issues using Repolinter. 
   * The issues this workflow scans for are determined by the ruleset specified by `with.config-url`: this ruleset will be maintained by the Open Source and Developer Advocacy team and will not change frequently.
 * Runs only on push to `master`, `main`, or `trunk`, ignoring PRs and other events.
 * If any policy issues are found, this workflow will open a GitHub issue titled "Open Source Policy Issues" and with the `repolinter` label. This issue will contain detailed information on which policies generated errors and what changes are suggested. An example issue is [here](https://github.com/aperture-science-incorporated/companion-cube/issues/44).
  * As policy issues are resolved, this workflow will update the open issue to reflect the changes. If all policy issues are resolved, the issue will automatically be closed.

This workflow is designed to cause the least amount of friction as possible:
 *  This means workflow will only run on push, and as a result will not participate in status checks for PRs. Furthermore, this workflow will always exit with a passing status unless a fatal internal error occurs.
 * The goal of this workflow was not to prevent work: this means that it is up to your team to backlog the items found by this tool appropriately. 
 * This workflow will only notify you when an issue is created. In other words, you will only be notified when new problems occur, but not when existing problems change.

What you should do:
 * Review this PR and workflow: make sure that the correct base branch is selected.
 * If it looks good, merge the PR and check to see if the repolinter-action runs successfully in the actions console. You can remove the branch created by this PR as it is no longer needed.
 * The action may open a GitHub issue on this repository (it will have the `repolinter` label). If an issue is opened, look it over and make sure all the problems seem correct. Shoot us a ping in #help-opensource if anything looks suspicious. 
 * In the future, this workflow may open issues as our open source policies are updated. Keep an eye on the GitHub issues for these updates (it may help to watch the repository).

This workflow is still in beta! If you have feedback, please let us know in #help-opensource. Thanks!